### PR TITLE
Improve german translations and use google options for EmploymentType

### DIFF
--- a/Configuration/NodeTypes.Mixin.JobPostingMixin.yaml
+++ b/Configuration/NodeTypes.Mixin.JobPostingMixin.yaml
@@ -117,6 +117,7 @@
           group: 'jobSettings'
           position: 'after jobPostingLocation'
     jobPostingEmploymentType:
+      defaultValue: 'FULL_TIME'
       type: string
       ui:
         label: i18n
@@ -125,6 +126,26 @@
         inspector:
           group: 'jobSettings'
           position: 'after jobPostingbaseSalary'
+          editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
+          editorOptions:
+            multiple: false
+            values:
+              'FULL_TIME':
+                label: i18n
+              'PART_TIME':
+                label: i18n
+              'CONTRACTOR':
+                label: i18n
+              'TEMPORARY':
+                label: i18n
+              'INTERN':
+                label: i18n
+              'VOLUNTEER':
+                label: i18n
+              'PER_DIEM':
+                label: i18n
+              'OTHER':
+                label: i18n
     jobPostingValidThrough:
       type: DateTime
       ui:

--- a/Configuration/NodeTypes.Mixin.JobPostingMixin.yaml
+++ b/Configuration/NodeTypes.Mixin.JobPostingMixin.yaml
@@ -37,7 +37,7 @@
               '@type': QuantitativeValue
               value: "${q(node).property('jobPostingBaseSalary')}"
               unitText: "YEAR"
-          employmentType: "${q(node).property('jobPostingEmploymentType')}"
+          employmentType: "Json.stringify(${q(node).property('jobPostingEmploymentType')})"
           validThrough: "${Date.format(q(node).property('jobPostingValidThrough'), 'Y-m-d')}"
   properties:
     jobPostingTitle:
@@ -117,8 +117,8 @@
           group: 'jobSettings'
           position: 'after jobPostingLocation'
     jobPostingEmploymentType:
-      defaultValue: 'FULL_TIME'
-      type: string
+      defaultValue: ['FULL_TIME']
+      type: array
       ui:
         label: i18n
         help:
@@ -128,7 +128,7 @@
           position: 'after jobPostingbaseSalary'
           editor: 'Neos.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
-            multiple: false
+            multiple: true
             values:
               'FULL_TIME':
                 label: i18n

--- a/Resources/Private/Fusion/Components/JobPosting.fusion
+++ b/Resources/Private/Fusion/Components/JobPosting.fusion
@@ -8,7 +8,7 @@ prototype(TechDivision.Jobs:Component.JobPosting) < prototype(Neos.Neos:ContentC
     jobPostingHiringOrganizationName = ${q(documentNode).property('jobPostingHiringOrganizationName')}
     jobPostingDatePosted = ${Date.format(documentNode.creationDateTime, 'Y-m-d')}
     jobPostingBaseSalary = ${q(documentNode).property('jobPostingBaseSalary')}
-    jobPostingEmploymentType = ${q(documentNode).property('jobPostingEmploymentType')}
+    jobPostingEmploymentType = ${Json.stringify(q(documentNode).property('jobPostingEmploymentType'))}
     jobPostingValidThrough = ${Date.format(q(documentNode).property('jobPostingValidThrough'), 'Y-m-d')}
     baseSalaryCurrency = ${Configuration.setting('TechDivision.Jobs.baseSalaryCurrency')}
     baseSalaryUnit = ${Configuration.setting('TechDivision.Jobs.baseSalaryUnit')}

--- a/Resources/Private/Translations/de/NodeTypes/Document/JobPosting.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Document/JobPosting.xlf
@@ -6,7 +6,7 @@
                 <target xml:lang="de">Stellenanzeige</target>
             </trans-unit>
             <trans-unit id="ui.help.message" xml:space="preserve">
-                <target xml:lang="de">Eine Stellenanzeige zum anzeigen von freien Stellen.</target>
+                <target xml:lang="de">Inhaltstyp zum Anzeigen von freien Stellen.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Translations/de/NodeTypes/Document/JobPostingOverview.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Document/JobPostingOverview.xlf
@@ -6,7 +6,7 @@
                 <target xml:lang="de">Karriere</target>
             </trans-unit>
             <trans-unit id="ui.help.message" xml:space="preserve">
-                <target xml:lang="de">Einstiegspunkt für alle Karriere spezifischen NodeTypes.</target>
+                <target xml:lang="de">Einstiegspunkt für alle karrierespezifischen NodeTypes.</target>
             </trans-unit>
             <trans-unit id="tabs.settings" xml:space="preserve">
                 <target xml:lang="de">Einstellungen</target>

--- a/Resources/Private/Translations/de/NodeTypes/JobList.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/JobList.xlf
@@ -27,13 +27,13 @@
                 <target xml:lang="de">Standort verbergen</target>
             </trans-unit>
             <trans-unit id="properties.hideJobPostingEmploymentType" xml:space="preserve">
-                <target xml:lang="de">Beschäftigungsgrad verbergen</target>
+                <target xml:lang="de">Beschäftigungsart verbergen</target>
             </trans-unit>
             <trans-unit id="label.tableHeading.jobPostingTitle" xml:space="preserve">
                 <target xml:lang="de">Stelle</target>
             </trans-unit>
             <trans-unit id="label.tableHeading.jobPostingEmploymentType" xml:space="preserve">
-                <target xml:lang="de">Beschäftigungsgrad</target>
+                <target xml:lang="de">Beschäftigungsart</target>
             </trans-unit>
             <trans-unit id="label.tableHeading.jobPostingPosition" xml:space="preserve">
                 <target xml:lang="de">Position</target>

--- a/Resources/Private/Translations/de/NodeTypes/JobLocation.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/JobLocation.xlf
@@ -6,10 +6,10 @@
                 <target xml:lang="de">Standort</target>
             </trans-unit>
             <trans-unit id="tabs.locationData" xml:space="preserve">
-                <target xml:lang="de">Location-Einstellungen</target>
+                <target xml:lang="de">Standort-Einstellungen</target>
             </trans-unit>
             <trans-unit id="groups.locationData" xml:space="preserve">
-                <target xml:lang="de">Location-Einstellungen</target>
+                <target xml:lang="de">Standort-Einstellungen</target>
             </trans-unit>
             <trans-unit id="properties.jobLocationTitle" xml:space="preserve">
                 <target xml:lang="de">Titel</target>
@@ -21,25 +21,25 @@
                 <target xml:lang="de">Straße</target>
             </trans-unit>
             <trans-unit id="properties.jobLocationStreetAddress.ui.help.message" xml:space="preserve">
-                <target xml:lang="de">Adresse der Straße. Zum Beispiel Max-Mustermann-Straße 5.</target>
+                <target xml:lang="de">Straße und Hausnummer des Standorts, zum Beispiel Max-Mustermann-Straße 5.</target>
             </trans-unit>
             <trans-unit id="properties.jobLocationAddressLocality" xml:space="preserve">
                 <target xml:lang="de">Stadt</target>
             </trans-unit>
             <trans-unit id="properties.jobLocationAddressLocality.ui.help.message" xml:space="preserve">
-                <target xml:lang="de">Die Stadt in der sich die Straßenadresse befindet.</target>
+                <target xml:lang="de">Stadt in der sich der Standort befindet.</target>
             </trans-unit>
             <trans-unit id="properties.jobLocationPostalCode" xml:space="preserve">
                 <target xml:lang="de">Postleitzahl</target>
             </trans-unit>
             <trans-unit id="properties.jobLocationPostalCode.ui.help.message" xml:space="preserve">
-                <target xml:lang="de">Die Postleitzahl. Zum Beispiel 83059.</target>
+                <target xml:lang="de">Die Postleitzahl des Standorts, zum Beispiel 83059.</target>
             </trans-unit>
             <trans-unit id="properties.jobLocationAddressRegion" xml:space="preserve">
                 <target xml:lang="de">Region</target>
             </trans-unit>
             <trans-unit id="properties.jobLocationAddressRegion.ui.help.message" xml:space="preserve">
-                <target xml:lang="de">Die Regin in der sich die Stadt befindet. Zum Beispiel Bayern.</target>
+                <target xml:lang="de">Die Region in der sich der Standort befindet, zum Beispiel Bayern.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Translations/de/NodeTypes/JobOrganization.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/JobOrganization.xlf
@@ -15,7 +15,7 @@
                 <target xml:lang="de">Organisation</target>
             </trans-unit>
             <trans-unit id="properties.jobPostingHiringOrganizationName.ui.help.message" xml:space="preserve">
-                <target xml:lang="de">Organisation die diese freie Stelle anbietet.</target>
+                <target xml:lang="de">Name der Organisation, die diese freie Stelle anbietet.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Translations/de/NodeTypes/JobPostingMixin.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/JobPostingMixin.xlf
@@ -50,6 +50,33 @@
             <trans-unit id="properties.jobPostingEmploymentType.ui.help.message" xml:space="preserve">
                 <target xml:lang="de">Art der Anstellung. Zum Beispiel Vollzeit oder Teilzeit.</target>
             </trans-unit>
+            <trans-unit id="properties.jobPostingEmploymentType.selectBoxEditor.values.FULL_TIME" xml:space="preserve">
+                <target xml:lang="de">Vollzeit</target>
+            </trans-unit>
+            <trans-unit id="properties.jobPostingEmploymentType.selectBoxEditor.values.PART_TIME" xml:space="preserve">
+                <target xml:lang="de">Teilzeit</target>
+            </trans-unit>
+            <trans-unit id="properties.jobPostingEmploymentType.selectBoxEditor.values.CONTRACTOR" xml:space="preserve">
+                <target xml:lang="de">Subunternehmer</target>
+            </trans-unit>
+            <trans-unit id="properties.jobPostingEmploymentType.selectBoxEditor.values.TEMPORARY" xml:space="preserve">
+                <source>Zeitarbeit</source>
+            </trans-unit>
+            <trans-unit id="properties.jobPostingEmploymentType.selectBoxEditor.values.INTERN" xml:space="preserve">
+                <source>Praktikum</source>
+            </trans-unit>
+            <trans-unit id="properties.jobPostingEmploymentType.selectBoxEditor.values.VOLUNTEER" xml:space="preserve">
+                <source>Freiwilligendienst</source>
+            </trans-unit>
+            <trans-unit id="properties.jobPostingEmploymentType.selectBoxEditor.values.PER_DIEM" xml:space="preserve">
+                <source>Tagelöhner</source>
+            </trans-unit>
+            <trans-unit id="properties.jobPostingEmploymentType.selectBoxEditor.values.OTHER" xml:space="preserve">
+                <source>Sontiges</source>
+            </trans-unit>
+            <trans-unit id="properties.jobPostingValidThrough" xml:space="preserve">
+                <source>Valid through</source>
+            </trans-unit>
             <trans-unit id="properties.jobPostingValidThrough" xml:space="preserve">
                 <target xml:lang="de">Gültig bis</target>
             </trans-unit>

--- a/Resources/Private/Translations/en/NodeTypes/JobPostingMixin.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/JobPostingMixin.xlf
@@ -50,6 +50,30 @@
             <trans-unit id="properties.jobPostingEmploymentType.ui.help.message" xml:space="preserve">
                 <source>Type of employment (e.g. full-time, part-time, contract, temporary, seasonal, internship).</source>
             </trans-unit>
+            <trans-unit id="properties.jobPostingEmploymentType.selectBoxEditor.values.FULL_TIME" xml:space="preserve">
+                <source>Full-time</source>
+            </trans-unit>
+            <trans-unit id="properties.jobPostingEmploymentType.selectBoxEditor.values.PART_TIME" xml:space="preserve">
+                <source>Part-time</source>
+            </trans-unit>
+            <trans-unit id="properties.jobPostingEmploymentType.selectBoxEditor.values.CONTRACTOR" xml:space="preserve">
+                <source>Contractor</source>
+            </trans-unit>
+            <trans-unit id="properties.jobPostingEmploymentType.selectBoxEditor.values.TEMPORARY" xml:space="preserve">
+                <source>Temporary work</source>
+            </trans-unit>
+            <trans-unit id="properties.jobPostingEmploymentType.selectBoxEditor.values.INTERN" xml:space="preserve">
+                <source>Internship</source>
+            </trans-unit>
+            <trans-unit id="properties.jobPostingEmploymentType.selectBoxEditor.values.VOLUNTEER" xml:space="preserve">
+                <source>Volunteer</source>
+            </trans-unit>
+            <trans-unit id="properties.jobPostingEmploymentType.selectBoxEditor.values.PER_DIEM" xml:space="preserve">
+                <source>Per diem</source>
+            </trans-unit>
+            <trans-unit id="properties.jobPostingEmploymentType.selectBoxEditor.values.OTHER" xml:space="preserve">
+                <source>Other</source>
+            </trans-unit>
             <trans-unit id="properties.jobPostingValidThrough" xml:space="preserve">
                 <source>Valid through</source>
             </trans-unit>


### PR DESCRIPTION
This pull requests improves the german translations and introduces a multi-selectbox for the EmploymentType.  
For google the employment type needs to be one of the following values:  FULL_TIME, PART_TIME, CONTRACTOR, TEMPORARY, INTERN, VOLUNTEER PER_DIEM or OTHER.
https://developers.google.com/search/docs/advanced/structured-data/job-posting?hl=en#job-posting-definition

Resolves https://github.com/techdivision/jobs/issues/5

Could you please create a new release with our changes, so we can update the composer package.
Thx in advance!