### PR TITLE
BUGFIX: LinkedData output

### DIFF
--- a/Configuration/NodeTypes.Content.JobOrganization.yaml
+++ b/Configuration/NodeTypes.Content.JobOrganization.yaml
@@ -21,11 +21,13 @@
   options:
     TtreeLinkedData:Generator:
       default:
+        context:
+          organizationLogo: "${q(node).property('jobPostingHiringOrganizationLogo')}"
         fragment:
           '@context': http://schema.org
           '@type': Organization
           name: "${q(node).property('jobPostingHiringOrganizationName')}"
-          logo: "${q(node).property('jobPostingHiringOrganizationLogo')}"
+          logo: "${organizationLogo && Neos.Link.resolveAssetUri('asset://' + organizationLogo.identifier)}"
   properties:
     jobPostingHiringOrganizationName:
       type: string

--- a/Configuration/NodeTypes.Mixin.JobPostingMixin.yaml
+++ b/Configuration/NodeTypes.Mixin.JobPostingMixin.yaml
@@ -24,12 +24,10 @@
           '@context': http://schema.org
           '@type': JobPosting
           title: "${q(node).property('jobPostingTitle')}"
-          description: "${String.stripTags(String.cropAtSentence(q(node).property('jobPostingDescription'), 180, '...'))}"
+          description: "${q(node).property('jobPostingDescription')}"
           datePosted: "${Date.format(node.creationDateTime, 'Y-m-d')}"
-          hiringOrganization:
-            '@type': Organization
-            name: "${q(jobOrganization).property('jobPostingHiringOrganizationName')}"
-          jobLocation: "${nextJobLocation ? LinkedData.List(nextJobLocation, preset, false) : null}"
+          hiringOrganization: "${jobOrganization && LinkedData.item(jobOrganization, preset, false)}"
+          jobLocation: "${nextJobLocation && LinkedData.List(nextJobLocation, preset, false)}"
           baseSalary:
             '@type': MonetaryAmount
             currency: "EUR"
@@ -37,7 +35,7 @@
               '@type': QuantitativeValue
               value: "${q(node).property('jobPostingBaseSalary')}"
               unitText: "YEAR"
-          employmentType: "Json.stringify(${q(node).property('jobPostingEmploymentType')})"
+          employmentType: "${Json.stringify(q(node).property('jobPostingEmploymentType'))}"
           validThrough: "${Date.format(q(node).property('jobPostingValidThrough'), 'Y-m-d')}"
   properties:
     jobPostingTitle:

--- a/Configuration/NodeTypes.Mixin.JobPostingMixin.yaml
+++ b/Configuration/NodeTypes.Mixin.JobPostingMixin.yaml
@@ -36,7 +36,7 @@
               value: "${q(node).property('jobPostingBaseSalary')}"
               unitText: "YEAR"
           employmentType: "${Json.stringify(q(node).property('jobPostingEmploymentType'))}"
-          validThrough: "${Date.format(q(node).property('jobPostingValidThrough'), 'Y-m-d')}"
+          validThrough: "${q(node).property('jobPostingValidThrough') && Date.format(q(node).property('jobPostingValidThrough'), 'Y-m-d')}"
   properties:
     jobPostingTitle:
       type: string
@@ -155,5 +155,3 @@
           position: 'after jobPostingEemploymentType'
           editorOptions:
             format: 'Y-m-d'
-      validation:
-        'Neos.Neos/Validation/NotEmptyValidator': []


### PR DESCRIPTION
### TechDivision.Jobs:JobPostingMixin
* Description	
	* should not be cropped, because its used as content of google jobs postings
	* should also not strip tags, because html is allowed
	* see https://developers.google.com/search/docs/advanced/structured-data/job-posting#standard-job
* hiringOrganization
	* use linkedData of JobOrganization
* employmentType
	* fix eel expression
* validThrough
	* remove NotEmptyValidator because this option is not required for google jobs

### TechDivision.Jobs:JobOrganization
* resolve image uri of organizationLogo for linked data

### Further thoughts
* property editor of jobPostingDescription sould be rich text editor until Neos 5, to format content easily
* not used data should not be rendered into JSON-LD, e.g. the whole baseSalary block, if no jobPostingBaseSalary is set